### PR TITLE
dropping many-to-many support

### DIFF
--- a/addon-manifest.json
+++ b/addon-manifest.json
@@ -9,8 +9,6 @@
       "STORJ_PASSWORD"
     ],
     "requires": [
-      "many_per_app",
-      "attachable"
     ],
     "regions": [
       "*"


### PR DESCRIPTION
Will revisit after GA.

Currently we are mishandling UUIDs for heroku' add-ons when supporting many-to-many. We will need a fix that is backwards compatible with the old email format.

Reference: https://devcenter.heroku.com/articles/making-your-add-on-shareable

This commit requires a `kensa push`