### PR TITLE
Allow legacy HEROKU_SSO tokens

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,7 +23,6 @@
   "undef": true,
   "unused": true,
   "maxparams": 4,
-  "maxstatements": 12,
   "maxdepth": 3,
   "maxlen": 80,
   "multistr": true,

--- a/config/index.js
+++ b/config/index.js
@@ -28,6 +28,7 @@ module.exports = {
   // is expecting
   heroku: {
     sso_salt: process.env.HEROKU_SSO || addonManifest.api.sso_salt,
+    legacy_salt: process.env.LEGACY_HASH || addonManifest.api.sso_salt,
     id: process.env.HEROKU_ID || addonManifest.id,
     password: process.env.HEROKU_PASSWORD || addonManifest.api.password
   },

--- a/config/index.js
+++ b/config/index.js
@@ -28,7 +28,7 @@ module.exports = {
   // is expecting
   heroku: {
     sso_salt: process.env.HEROKU_SSO || addonManifest.api.sso_salt,
-    legacy_salt: process.env.LEGACY_HASH || addonManifest.api.sso_salt,
+    legacy_salt: process.env.LEGACY_SSO || addonManifest.api.sso_salt,
     id: process.env.HEROKU_ID || addonManifest.id,
     password: process.env.HEROKU_PASSWORD || addonManifest.api.password
   },

--- a/dockerfiles/bridge.Dockerfile
+++ b/dockerfiles/bridge.Dockerfile
@@ -1,14 +1,15 @@
-FROM nodesource/node:4
+FROM node:6
 
 RUN rm -rf /usr/src/app
-RUN git clone https://github.com/Storj/bridge.git /usr/src/app
+RUN git clone https://github.com/Storj/bridge.git /usr/src/app \
+ && cd /usr/src/app \
+ && git checkout 52e6fc5e1bea4a3d762bb1e47b0fb24426cdf0e6
 WORKDIR /usr/src/app
 
 ENV NODE_ENV integration
 
-RUN npm install --production
-
-RUN npm link
+RUN npm install --production \
+ && npm link
 
 RUN mkdir -p ./.storj-bridge/config
 ENV STORJ_BRIDGE_DIR /usr/src/app
@@ -30,13 +31,10 @@ RUN echo ' \
     "timeout": 60000, \
     "port": 8080 \
   }, \
-  "storage": [ \
-    { \
-      "name": "bridge", \
-      "host": "service_bridge_mongodb", \
-      "port": 27017 \
-    } \
-  ], \
+  "storage":{ \
+      "mongoUrl": "mongodb://service_bridge_mongodb:27017/bridge", \
+      "mongoOpts": {} \
+  }, \
   "messaging": { \
     "url": "amqp://service_bridge_rabbitmq", \
     "queues": { \

--- a/dockerfiles/heroku.Dockerfile
+++ b/dockerfiles/heroku.Dockerfile
@@ -1,4 +1,4 @@
-FROM nodesource/node:4
+FROM node:6
 
 RUN curl https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64 > /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init

--- a/dockerfiles/mailgun.Dockerfile
+++ b/dockerfiles/mailgun.Dockerfile
@@ -1,4 +1,4 @@
-FROM nodesource/node:4
+FROM node:6
 
 ADD ./mock-mailgun/package.json .
 RUN npm install

--- a/dockerfiles/server.Dockerfile
+++ b/dockerfiles/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM nodesource/node:4
+FROM node:6
 
 RUN curl -SsL https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64 > /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init


### PR DESCRIPTION
Allows us to update via kensa and gracefully handle the change. We can
revert this change once heroku begins using the new token.

CC:// @phutchins 